### PR TITLE
fix: fix typo

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "plasmax-core",
   "version": "0.17.0-dev.0",
   "author": "Alex Czech <yakutoc@gmail.com>",
+  "description": "asd",
   "license": "MIT",
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install plasmax-core@0.17.1-canary.203.6470095199.0
  npm install plasmax-hope@0.19.1-canary.203.6470095199.0
  npm install plasmax-rew@0.15.1-canary.203.6470095199.0
  npm install plasmax-web@0.48.1-canary.203.6470095199.0
  # or 
  yarn add plasmax-core@0.17.1-canary.203.6470095199.0
  yarn add plasmax-hope@0.19.1-canary.203.6470095199.0
  yarn add plasmax-rew@0.15.1-canary.203.6470095199.0
  yarn add plasmax-web@0.48.1-canary.203.6470095199.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
